### PR TITLE
Implement email assistant Android skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Gradle files
+.gradle
+local.properties
+
+# Build outputs
+*/build/
+
+# Android Studio
+.idea
+
+# Misc
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Mail Assistant Android App
+
+This is a minimal example of an Android app that fetches emails, analyzes them using an AI model, and creates events or tasks based on the email content. When a task is created, a push notification is displayed.
+
+The implementation is simplified with placeholders for Gmail, Google Calendar, and Google Tasks API integrations, as well as AI analysis (e.g., using Google Gemini). These parts need to be implemented with actual API calls and authentication logic.
+
+## Structure
+- `MainActivity.kt` – entry point of the app
+- `GmailHelper.kt` – fetches emails (placeholder)
+- `AiHelper.kt` – performs AI analysis of emails
+- `CalendarHelper.kt` – adds events to Google Calendar
+- `TasksHelper.kt` – adds tasks to Google Tasks and triggers notifications
+- `NotificationHelper.kt` – handles push notifications
+
+## Building
+This project uses Gradle. Open it in Android Studio or run `./gradlew assembleDebug` to build the APK. Ensure you have the Android SDK installed.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    compileSdk 34
+    defaultConfig {
+        applicationId "com.example.mailassi"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,3 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /usr/local/android-sdk/tools/proguard/proguard-android.txt

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.mailassi">
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/com/example/mailassi/AiHelper.kt
+++ b/app/src/main/java/com/example/mailassi/AiHelper.kt
@@ -1,0 +1,21 @@
+package com.example.mailassi
+
+import android.content.Context
+
+/**
+ * This class represents a stub for the AI model that analyzes an email and
+ * determines if it contains an event or a task.
+ */
+class AiHelper(private val context: Context) {
+    data class AnalysisResult(
+        val isEvent: Boolean,
+        val isTask: Boolean,
+        val title: String?,
+        val time: Long?
+    )
+
+    fun analyzeEmail(email: GmailHelper.Email): AnalysisResult {
+        // TODO: Replace with actual AI/LLM call (e.g., Google Gemini)
+        return AnalysisResult(isEvent = false, isTask = false, title = null, time = null)
+    }
+}

--- a/app/src/main/java/com/example/mailassi/CalendarHelper.kt
+++ b/app/src/main/java/com/example/mailassi/CalendarHelper.kt
@@ -1,0 +1,13 @@
+package com.example.mailassi
+
+import android.content.Context
+
+/**
+ * Helper class for creating calendar events using Google Calendar API.
+ * This is a simplified placeholder implementation.
+ */
+class CalendarHelper(private val context: Context) {
+    fun createEvent(title: String, description: String, time: Long?) {
+        // TODO: Implement Google Calendar API integration
+    }
+}

--- a/app/src/main/java/com/example/mailassi/EmailAnalyzer.kt
+++ b/app/src/main/java/com/example/mailassi/EmailAnalyzer.kt
@@ -1,0 +1,31 @@
+package com.example.mailassi
+
+import android.content.Context
+
+/**
+ * Coordinates fetching emails, analyzing them, and creating events or tasks.
+ */
+class EmailAnalyzer(private val context: Context) {
+    private val gmail = GmailHelper(context)
+    private val ai = AiHelper(context)
+    private val calendar = CalendarHelper(context)
+    private val tasks = TasksHelper(context)
+    private val notifications = NotificationHelper(context)
+
+    fun process() {
+        val emails = gmail.fetchLatestEmails()
+        for (email in emails) {
+            val result = ai.analyzeEmail(email)
+            val notes = email.body
+            result.title?.let { title ->
+                if (result.isEvent) {
+                    calendar.createEvent(title, notes, result.time)
+                }
+                if (result.isTask) {
+                    tasks.createTask(title, notes)
+                    notifications.notifyTask(title)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mailassi/GmailHelper.kt
+++ b/app/src/main/java/com/example/mailassi/GmailHelper.kt
@@ -1,0 +1,16 @@
+package com.example.mailassi
+
+import android.content.Context
+
+/**
+ * Placeholder for Gmail API integration. In a real implementation this class
+ * would handle OAuth authentication and fetch messages from the user's inbox.
+ */
+class GmailHelper(private val context: Context) {
+    data class Email(val subject: String, val body: String)
+
+    fun fetchLatestEmails(): List<Email> {
+        // TODO: Implement Gmail API integration
+        return emptyList()
+    }
+}

--- a/app/src/main/java/com/example/mailassi/MainActivity.kt
+++ b/app/src/main/java/com/example/mailassi/MainActivity.kt
@@ -1,0 +1,14 @@
+package com.example.mailassi
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.example.mailassi.R
+import com.example.mailassi.EmailAnalyzer
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        EmailAnalyzer(this).process()
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/app/src/main/java/com/example/mailassi/NotificationHelper.kt
+++ b/app/src/main/java/com/example/mailassi/NotificationHelper.kt
@@ -1,0 +1,43 @@
+package com.example.mailassi
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+
+/**
+ * Helper to send push notifications when a task is created.
+ */
+class NotificationHelper(private val context: Context) {
+    private val channelId = "mail_assi_channel"
+
+    init {
+        createChannel()
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                channelId,
+                "Mail Assistant Notifications",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            val manager = context.getSystemService(NotificationManager::class.java)
+            manager?.createNotificationChannel(channel)
+        }
+    }
+
+    fun notifyTask(title: String) {
+        val builder = NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle("New Task")
+            .setContentText(title)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+        with(NotificationManagerCompat.from(context)) {
+            notify(title.hashCode(), builder.build())
+        }
+    }
+}

--- a/app/src/main/java/com/example/mailassi/TasksHelper.kt
+++ b/app/src/main/java/com/example/mailassi/TasksHelper.kt
@@ -1,0 +1,13 @@
+package com.example.mailassi
+
+import android.content.Context
+
+/**
+ * Helper class for creating tasks using Google Tasks API.
+ * This is a simplified placeholder implementation.
+ */
+class TasksHelper(private val context: Context) {
+    fun createTask(title: String, notes: String) {
+        // TODO: Implement Google Tasks API integration
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Mail Assistant" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Mail Assistant</string>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+include ':app'


### PR DESCRIPTION
## Summary
- initialize Android project structure
- add helpers for Gmail, AI analysis, Google Calendar, Google Tasks and notifications
- wire up simple EmailAnalyzer in MainActivity
- provide Gradle build configuration
- add README with building instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68836cf4dccc8325aca29bf6b8ccb271